### PR TITLE
Migrate to django4

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,9 @@
 ## Important functionality
 
 * Add Backup / Restore ability for posts, tags, etc.
+* Send email to post author when a comment is posted to that post.
+* Option for commenters to get sent an email if another comment is added to a
+  post they have commented on.
 * Add the ability to pin a post from its edit page. Also, warn that doing this
   will unpin the current pinned post. Superuser only.
 * ~~style Paragraphs (more space below), links and lists (they are default),
@@ -50,6 +53,10 @@
 
 ### Comments
 
+* Comment form should be on same page as the post, at the botton. This allows
+  commenter to refer easily back to the post if needed.
+* After posting a comment, automatically scroll down to that comment instead of
+  back to top of page.
 * Offer to remember commenter for next visit, already uses  credentials from
   logged in user if applicable.
 * ~~Integrate an HTML editor. Could use markdown but it gives unexpected results

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ django-ckeditor>=6.1.0,<6.5.0
 django-compressor>=3.1,<4.1
 django-gravatar2>=1.4.4,<1.5.0
 django-htmlmin>=0.11.0,<0.12.0
-django-likes>=2.0.1,<2.1.0
+# django-likes>=2.0.1,<2.1.0
+git+https://github.com/seapagan/django-likes.git@develop
 django-maintenance-mode>=0.16.1,<0.17.0
 django-recaptcha>=2.0.6,<3.1.0
 django-rundevserver>=0.3.1,<0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,8 @@ django-user-sessions>=1.7.1,<1.8.0
 django-xforwardedfor-middleware==2.0
 djangorestframework>=3.13.1,<3.14.0
 dj-hitcount>=1.1.0,<1.4.0
-dj-pagination>=2.5.0,<2.6.0
+# dj-pagination>=2.5.0,<2.6.0
+git+https://github.com/seapagan/dj-pagination.git@master
 geoip2>=4.4.0,<4.7.0
 pillow>=8.3.1,<9.2.0
 python-dotenv>=0.19.1,<0.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,8 @@ django-maintenance-mode>=0.16.1,<0.17.0
 django-recaptcha>=2.0.6,<3.1.0
 django-rundevserver>=0.3.1,<0.4.0
 django-secretballot>=2.0.0,<2.1.0
-django-user-sessions>=1.7.1,<1.8.0
+# django-user-sessions>=1.7.1,<1.8.0
+git+https://github.com/jazzband/django-user-sessions.git@a15cd695360d19eb608e1cf8684ea3d2529ba9f7
 django-xforwardedfor-middleware==2.0
 djangorestframework>=3.13.1,<3.14.0
 dj-hitcount>=1.1.0,<1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>=3.2.6,<4.0.0
+django>=4.0.0,<4.1.0
 django-ckeditor>=6.1.0,<6.5.0
 django-compressor>=3.1,<4.1
 django-gravatar2>=1.4.4,<1.5.0
@@ -10,7 +10,7 @@ django-rundevserver>=0.3.1,<0.4.0
 django-secretballot>=2.0.0,<2.1.0
 django-user-sessions>=1.7.1,<1.8.0
 django-xforwardedfor-middleware==2.0
-djangorestframework>=3.12.4,<3.14.0
+djangorestframework>=3.13.1,<3.14.0
 dj-hitcount>=1.1.0,<1.4.0
 dj-pagination>=2.5.0,<2.6.0
 geoip2>=4.4.0,<4.7.0


### PR DESCRIPTION
Migrate the App to Django 4, fixing issues as found.

The following third-party apps fail but are largely unmaintained, so I have forked and fixed the issues. These apps will now be pulled directly from my Github.
* `dj-pagination` (Use my Fork)
* `django-user-sessions` (actually fixed in their Repo, we now pull directly from a good commit there since there is no updated package.)
* `django-likes` (some issues fixed in their repo but not all, we use my Fork)